### PR TITLE
Fix PHP notices when auto-registering post types

### DIFF
--- a/registration/registration.php
+++ b/registration/registration.php
@@ -16,8 +16,8 @@ namespace WPCOMVIP\Decoupled\Registration;
 function register_custom_post_types( $args, $post_type ) {
 	if (
 		isset( $args['show_in_graphql'] ) ||
-		true === $args['_builtin'] ||
-		false === $args['public']
+		( isset( $args['_builtin'] ) && true === $args['_builtin'] ) ||
+		( isset( $args['public'] ) && false === $args['public'] )
 	) {
 		return $args;
 	}


### PR DESCRIPTION
This adds `isset()` checks for the `_builtin` and `public` registration args before checking their value to avoid an "Undefined index" notice.